### PR TITLE
Add reportes menu

### DIFF
--- a/src/app/features/reportes/pages/menu/menu.html
+++ b/src/app/features/reportes/pages/menu/menu.html
@@ -1,0 +1,8 @@
+<section class="reportes-menu">
+  <h1>Reportes disponibles</h1>
+  <ul>
+    <li><a routerLink="/reportes/usuarios/ventas">Ventas</a></li>
+    <li><a routerLink="/reportes/usuarios/productos">Productos por usuario</a></li>
+    <li><a routerLink="/reportes/usuarios/usuarios">Usuarios</a></li>
+  </ul>
+</section>

--- a/src/app/features/reportes/pages/menu/menu.scss
+++ b/src/app/features/reportes/pages/menu/menu.scss
@@ -1,0 +1,27 @@
+.reportes-menu {
+  padding: 2rem;
+  h1 {
+    text-align: center;
+  }
+  ul {
+    list-style: none;
+    padding: 0;
+    max-width: 400px;
+    margin: 2rem auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+  a {
+    text-decoration: none;
+    padding: 0.75rem 1rem;
+    background-color: #f0f0f0;
+    border-radius: 8px;
+    color: #333;
+    text-align: center;
+    transition: background-color 0.3s;
+    &:hover {
+      background-color: #d0d0d0;
+    }
+  }
+}

--- a/src/app/features/reportes/pages/menu/menu.spec.ts
+++ b/src/app/features/reportes/pages/menu/menu.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ReportesMenu } from './menu';
+
+describe('ReportesMenu', () => {
+  let component: ReportesMenu;
+  let fixture: ComponentFixture<ReportesMenu>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ReportesMenu]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ReportesMenu);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/reportes/pages/menu/menu.ts
+++ b/src/app/features/reportes/pages/menu/menu.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-reportes-menu',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './menu.html',
+  styleUrl: './menu.scss'
+})
+export class ReportesMenu {}

--- a/src/app/features/reportes/reportes-routing.module.ts
+++ b/src/app/features/reportes/reportes-routing.module.ts
@@ -1,8 +1,10 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { UsuariosModule } from './usuarios/usuarios.module';
+import { ReportesMenu } from './pages/menu/menu';
 
 const routes: Routes = [
+  { path: '', component: ReportesMenu },
   {path: 'usuarios', loadChildren: () => import('./usuarios/usuarios.module').then(m => m.UsuariosModule)},
 
 ];

--- a/src/app/features/reportes/reportes.module.ts
+++ b/src/app/features/reportes/reportes.module.ts
@@ -4,6 +4,7 @@ import { CommonModule } from '@angular/common';
 import { ReportesRoutingModule } from './reportes-routing.module';
 import { Ventas } from './usuarios/pages/ventas/ventas';
 import { RouterModule } from '@angular/router';
+import { ReportesMenu } from './pages/menu/menu';
 
 
 @NgModule({
@@ -12,7 +13,8 @@ import { RouterModule } from '@angular/router';
     CommonModule,
     ReportesRoutingModule,
     Ventas,
-    RouterModule
+    RouterModule,
+    ReportesMenu
   ]
 })
 export class ReportesModule { }


### PR DESCRIPTION
## Summary
- add a new menu page for the reports section
- show list of available reports
- register the menu page in routing and module

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b50091f08832b907fe8c1c705cc9c