### PR TITLE
Fix inventory route under reportes

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -3,7 +3,7 @@
   <aside class="sidebar" *ngIf="!isAuthRoute">
     <div class="brand">Vending Co.</div>
     <nav class="menu">
-      <a routerLink="/" routerLinkActive="active">Inicio</a>
+      <a routerLink="/inicio" routerLinkActive="active">Inicio</a>
       <a routerLink="/reportes" routerLinkActive="active">Reportes</a>
       <a routerLink="/operaciones" routerLinkActive="active">Operaciones</a>
       <a routerLink="/configuracion" routerLinkActive="active">Configuración</a>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -3,6 +3,11 @@ import { Routes } from '@angular/router';
 export const routes: Routes = [
   {
     path: '',
+    redirectTo: 'auth',
+    pathMatch: 'full'
+  },
+  {
+    path: 'inicio',
     loadChildren: () =>
       import('./features/inicio/inicio.module').then(m => m.InicioModule)
   },

--- a/src/app/features/auth/pages/login/login.ts
+++ b/src/app/features/auth/pages/login/login.ts
@@ -17,7 +17,7 @@ export class LoginComponent {
 
   login() {
     if (this.username && this.password) {
-      this.router.navigate(['/']); // o a dashboard
+      this.router.navigate(['/inicio']);
     } else {
       alert('Datos incorrectos');
     }

--- a/src/app/features/inicio/pages/home/home.html
+++ b/src/app/features/inicio/pages/home/home.html
@@ -4,6 +4,7 @@
 
   <div class="menu">
     <a routerLink="/reportes/usuarios/ventas" class="card">📊 Reportes</a>
+    <a routerLink="/reportes/vending/inventario" class="card">📦 Inventario</a>
     <a routerLink="/reportes" class="card">⚙️ Operaciones</a>
     <a routerLink="/configuracion" class="card">🔧 Configuración</a>
   </div>

--- a/src/app/features/inventario/inventario-routing.module.ts
+++ b/src/app/features/inventario/inventario-routing.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { Inventario } from './pages/inventario/inventario';
+
+const routes: Routes = [
+  { path: '', component: Inventario },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class InventarioRoutingModule {}

--- a/src/app/features/inventario/inventario.module.ts
+++ b/src/app/features/inventario/inventario.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { InventarioRoutingModule } from './inventario-routing.module';
+import { Inventario } from './pages/inventario/inventario';
+
+@NgModule({
+  declarations: [],
+  imports: [
+    CommonModule,
+    RouterModule,
+    Inventario,
+    InventarioRoutingModule
+  ]
+})
+export class InventarioModule {}

--- a/src/app/features/inventario/pages/inventario/inventario.html
+++ b/src/app/features/inventario/pages/inventario/inventario.html
@@ -1,0 +1,4 @@
+<section class="inventario">
+  <h1>Inventario</h1>
+  <p>Aquí se mostrará el inventario de máquinas vending.</p>
+</section>

--- a/src/app/features/inventario/pages/inventario/inventario.scss
+++ b/src/app/features/inventario/pages/inventario/inventario.scss
@@ -1,0 +1,3 @@
+.inventario {
+  padding: 1rem;
+}

--- a/src/app/features/inventario/pages/inventario/inventario.ts
+++ b/src/app/features/inventario/pages/inventario/inventario.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-inventario',
+  standalone: true,
+  templateUrl: './inventario.html',
+  styleUrl: './inventario.scss'
+})
+export class Inventario {}

--- a/src/app/features/reportes/pages/menu/menu.html
+++ b/src/app/features/reportes/pages/menu/menu.html
@@ -4,5 +4,6 @@
     <li><a routerLink="/reportes/usuarios/ventas">Ventas</a></li>
     <li><a routerLink="/reportes/usuarios/productos">Productos por usuario</a></li>
     <li><a routerLink="/reportes/usuarios/usuarios">Usuarios</a></li>
+    <li><a routerLink="/reportes/vending/inventario">Inventario de máquinas</a></li>
   </ul>
 </section>

--- a/src/app/features/reportes/reportes-routing.module.ts
+++ b/src/app/features/reportes/reportes-routing.module.ts
@@ -6,6 +6,7 @@ import { ReportesMenu } from './pages/menu/menu';
 const routes: Routes = [
   { path: '', component: ReportesMenu },
   {path: 'usuarios', loadChildren: () => import('./usuarios/usuarios.module').then(m => m.UsuariosModule)},
+  {path: 'vending/inventario', loadChildren: () => import('../inventario/inventario.module').then(m => m.InventarioModule)},
 
 ];
 

--- a/src/app/features/reportes/reportes.module.ts
+++ b/src/app/features/reportes/reportes.module.ts
@@ -5,6 +5,7 @@ import { ReportesRoutingModule } from './reportes-routing.module';
 import { Ventas } from './usuarios/pages/ventas/ventas';
 import { RouterModule } from '@angular/router';
 import { ReportesMenu } from './pages/menu/menu';
+import { Inventario } from '../inventario/pages/inventario/inventario';
 
 
 @NgModule({
@@ -14,7 +15,8 @@ import { ReportesMenu } from './pages/menu/menu';
     ReportesRoutingModule,
     Ventas,
     RouterModule,
-    ReportesMenu
+    ReportesMenu,
+    Inventario
   ]
 })
 export class ReportesModule { }


### PR DESCRIPTION
## Summary
- route root to auth login
- place `InventarioModule` under `/reportes/vending/inventario`
- link to inventory page from home and reports menu
- import `Inventario` component in `ReportesModule`

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b55828998832bad0a274560011839