### PR TITLE
Add admin sections for vending manager

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -6,6 +6,9 @@
       <a routerLink="/inicio" routerLinkActive="active">Inicio</a>
       <a routerLink="/reportes" routerLinkActive="active">Reportes</a>
       <a routerLink="/operaciones" routerLinkActive="active">Operaciones</a>
+      <a routerLink="/usuarios" routerLinkActive="active">Usuarios</a>
+      <a routerLink="/empleados" routerLinkActive="active">Empleados</a>
+      <a routerLink="/almacenes" routerLinkActive="active">Almacenes</a>
       <a routerLink="/configuracion" routerLinkActive="active">Configuración</a>
     </nav>
   </aside>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -17,6 +17,26 @@ export const routes: Routes = [
       import('./features/reportes/reportes.module').then(m => m.ReportesModule)
   },
   {
+    path: 'operaciones',
+    loadChildren: () =>
+      import('./features/operaciones/operaciones.module').then(m => m.OperacionesModule)
+  },
+  {
+    path: 'usuarios',
+    loadChildren: () =>
+      import('./features/usuarios/usuarios.module').then(m => m.UsuariosModule)
+  },
+  {
+    path: 'empleados',
+    loadChildren: () =>
+      import('./features/empleados/empleados.module').then(m => m.EmpleadosModule)
+  },
+  {
+    path: 'almacenes',
+    loadChildren: () =>
+      import('./features/almacenes/almacenes.module').then(m => m.AlmacenesModule)
+  },
+  {
     path: 'auth',
     loadChildren: () =>
       import('./features/auth/auth/auth.module').then(m => m.AuthModule)

--- a/src/app/features/almacenes/almacenes-routing.module.ts
+++ b/src/app/features/almacenes/almacenes-routing.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { AlmacenesMenu } from './pages/menu/menu';
+import { Almacenes } from './pages/almacenes/almacenes';
+
+const routes: Routes = [
+  { path: '', component: AlmacenesMenu },
+  { path: 'almacenes', component: Almacenes },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class AlmacenesRoutingModule {}

--- a/src/app/features/almacenes/almacenes.module.ts
+++ b/src/app/features/almacenes/almacenes.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { AlmacenesRoutingModule } from './almacenes-routing.module';
+import { AlmacenesMenu } from './pages/menu/menu';
+import { Almacenes } from './pages/almacenes/almacenes';
+
+@NgModule({
+  declarations: [],
+  imports: [
+    CommonModule,
+    RouterModule,
+    AlmacenesMenu,
+    Almacenes,
+    AlmacenesRoutingModule
+  ]
+})
+export class AlmacenesModule {}

--- a/src/app/features/almacenes/pages/almacenes/almacenes.html
+++ b/src/app/features/almacenes/pages/almacenes/almacenes.html
@@ -1,0 +1,4 @@
+<section class="almacenes">
+  <h1>Almacenes</h1>
+  <p>Administración de almacenes: agregar o quitar.</p>
+</section>

--- a/src/app/features/almacenes/pages/almacenes/almacenes.scss
+++ b/src/app/features/almacenes/pages/almacenes/almacenes.scss
@@ -1,0 +1,3 @@
+.almacenes {
+  padding: 2rem;
+}

--- a/src/app/features/almacenes/pages/almacenes/almacenes.ts
+++ b/src/app/features/almacenes/pages/almacenes/almacenes.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-almacenes',
+  standalone: true,
+  templateUrl: './almacenes.html',
+  styleUrl: './almacenes.scss'
+})
+export class Almacenes {}

--- a/src/app/features/almacenes/pages/menu/menu.html
+++ b/src/app/features/almacenes/pages/menu/menu.html
@@ -1,0 +1,6 @@
+<section class="almacenes-menu">
+  <h1>Almacenes</h1>
+  <ul>
+    <li><a routerLink="almacenes">Listado</a></li>
+  </ul>
+</section>

--- a/src/app/features/almacenes/pages/menu/menu.scss
+++ b/src/app/features/almacenes/pages/menu/menu.scss
@@ -1,0 +1,3 @@
+.almacenes-menu {
+  padding: 2rem;
+}

--- a/src/app/features/almacenes/pages/menu/menu.ts
+++ b/src/app/features/almacenes/pages/menu/menu.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-almacenes-menu',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './menu.html',
+  styleUrl: './menu.scss'
+})
+export class AlmacenesMenu {}

--- a/src/app/features/empleados/empleados-routing.module.ts
+++ b/src/app/features/empleados/empleados-routing.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { EmpleadosMenu } from './pages/menu/menu';
+import { Empleados } from './pages/empleados/empleados';
+import { Areas } from './pages/areas/areas';
+import { Departamentos } from './pages/departamentos/departamentos';
+
+const routes: Routes = [
+  { path: '', component: EmpleadosMenu },
+  { path: 'empleados', component: Empleados },
+  { path: 'areas', component: Areas },
+  { path: 'departamentos', component: Departamentos },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class EmpleadosRoutingModule {}

--- a/src/app/features/empleados/empleados.module.ts
+++ b/src/app/features/empleados/empleados.module.ts
@@ -1,0 +1,22 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { EmpleadosRoutingModule } from './empleados-routing.module';
+import { EmpleadosMenu } from './pages/menu/menu';
+import { Empleados } from './pages/empleados/empleados';
+import { Areas } from './pages/areas/areas';
+import { Departamentos } from './pages/departamentos/departamentos';
+
+@NgModule({
+  declarations: [],
+  imports: [
+    CommonModule,
+    RouterModule,
+    EmpleadosMenu,
+    Empleados,
+    Areas,
+    Departamentos,
+    EmpleadosRoutingModule
+  ]
+})
+export class EmpleadosModule {}

--- a/src/app/features/empleados/pages/areas/areas.html
+++ b/src/app/features/empleados/pages/areas/areas.html
@@ -1,0 +1,4 @@
+<section class="areas">
+  <h1>Áreas</h1>
+  <p>Creación y eliminación de áreas.</p>
+</section>

--- a/src/app/features/empleados/pages/areas/areas.scss
+++ b/src/app/features/empleados/pages/areas/areas.scss
@@ -1,0 +1,3 @@
+.areas {
+  padding: 2rem;
+}

--- a/src/app/features/empleados/pages/areas/areas.ts
+++ b/src/app/features/empleados/pages/areas/areas.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-areas',
+  standalone: true,
+  templateUrl: './areas.html',
+  styleUrl: './areas.scss'
+})
+export class Areas {}

--- a/src/app/features/empleados/pages/departamentos/departamentos.html
+++ b/src/app/features/empleados/pages/departamentos/departamentos.html
@@ -1,0 +1,4 @@
+<section class="departamentos">
+  <h1>Departamentos</h1>
+  <p>Crear y quitar departamentos.</p>
+</section>

--- a/src/app/features/empleados/pages/departamentos/departamentos.scss
+++ b/src/app/features/empleados/pages/departamentos/departamentos.scss
@@ -1,0 +1,3 @@
+.departamentos {
+  padding: 2rem;
+}

--- a/src/app/features/empleados/pages/departamentos/departamentos.ts
+++ b/src/app/features/empleados/pages/departamentos/departamentos.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-departamentos',
+  standalone: true,
+  templateUrl: './departamentos.html',
+  styleUrl: './departamentos.scss'
+})
+export class Departamentos {}

--- a/src/app/features/empleados/pages/empleados/empleados.html
+++ b/src/app/features/empleados/pages/empleados/empleados.html
@@ -1,0 +1,4 @@
+<section class="empleados">
+  <h1>Empleados</h1>
+  <p>Gestión de datos de empleados.</p>
+</section>

--- a/src/app/features/empleados/pages/empleados/empleados.scss
+++ b/src/app/features/empleados/pages/empleados/empleados.scss
@@ -1,0 +1,3 @@
+.empleados {
+  padding: 2rem;
+}

--- a/src/app/features/empleados/pages/empleados/empleados.ts
+++ b/src/app/features/empleados/pages/empleados/empleados.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-empleados',
+  standalone: true,
+  templateUrl: './empleados.html',
+  styleUrl: './empleados.scss'
+})
+export class Empleados {}

--- a/src/app/features/empleados/pages/menu/menu.html
+++ b/src/app/features/empleados/pages/menu/menu.html
@@ -1,0 +1,8 @@
+<section class="empleados-menu">
+  <h1>Empleados</h1>
+  <ul>
+    <li><a routerLink="empleados">Empleados</a></li>
+    <li><a routerLink="areas">Áreas</a></li>
+    <li><a routerLink="departamentos">Departamentos</a></li>
+  </ul>
+</section>

--- a/src/app/features/empleados/pages/menu/menu.scss
+++ b/src/app/features/empleados/pages/menu/menu.scss
@@ -1,0 +1,3 @@
+.empleados-menu {
+  padding: 2rem;
+}

--- a/src/app/features/empleados/pages/menu/menu.ts
+++ b/src/app/features/empleados/pages/menu/menu.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-empleados-menu',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './menu.html',
+  styleUrl: './menu.scss'
+})
+export class EmpleadosMenu {}

--- a/src/app/features/inicio/pages/home/home.html
+++ b/src/app/features/inicio/pages/home/home.html
@@ -5,7 +5,10 @@
   <div class="menu">
     <a routerLink="/reportes/usuarios/ventas" class="card">📊 Reportes</a>
     <a routerLink="/reportes/vending/inventario" class="card">📦 Inventario</a>
-    <a routerLink="/reportes" class="card">⚙️ Operaciones</a>
+    <a routerLink="/operaciones" class="card">⚙️ Operaciones</a>
+    <a routerLink="/usuarios" class="card">👥 Usuarios</a>
+    <a routerLink="/empleados" class="card">🏢 Empleados</a>
+    <a routerLink="/almacenes" class="card">🏬 Almacenes</a>
     <a routerLink="/configuracion" class="card">🔧 Configuración</a>
   </div>
 </section>

--- a/src/app/features/operaciones/operaciones-routing.module.ts
+++ b/src/app/features/operaciones/operaciones-routing.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { OperacionesMenu } from './pages/menu/menu';
+import { Planograma } from './pages/planograma/planograma';
+import { Resurtido } from './pages/resurtido/resurtido';
+import { Permisos } from './pages/permisos/permisos';
+
+const routes: Routes = [
+  { path: '', component: OperacionesMenu },
+  { path: 'planograma', component: Planograma },
+  { path: 'resurtido', component: Resurtido },
+  { path: 'permisos', component: Permisos },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class OperacionesRoutingModule {}

--- a/src/app/features/operaciones/operaciones.module.ts
+++ b/src/app/features/operaciones/operaciones.module.ts
@@ -1,0 +1,22 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { OperacionesRoutingModule } from './operaciones-routing.module';
+import { OperacionesMenu } from './pages/menu/menu';
+import { Planograma } from './pages/planograma/planograma';
+import { Resurtido } from './pages/resurtido/resurtido';
+import { Permisos } from './pages/permisos/permisos';
+
+@NgModule({
+  declarations: [],
+  imports: [
+    CommonModule,
+    RouterModule,
+    OperacionesMenu,
+    Planograma,
+    Resurtido,
+    Permisos,
+    OperacionesRoutingModule
+  ]
+})
+export class OperacionesModule {}

--- a/src/app/features/operaciones/pages/menu/menu.html
+++ b/src/app/features/operaciones/pages/menu/menu.html
@@ -1,0 +1,8 @@
+<section class="operaciones-menu">
+  <h1>Operaciones</h1>
+  <ul>
+    <li><a routerLink="planograma">Planograma</a></li>
+    <li><a routerLink="resurtido">Resurtido</a></li>
+    <li><a routerLink="permisos">Permisos por usuario</a></li>
+  </ul>
+</section>

--- a/src/app/features/operaciones/pages/menu/menu.scss
+++ b/src/app/features/operaciones/pages/menu/menu.scss
@@ -1,0 +1,3 @@
+.operaciones-menu {
+  padding: 2rem;
+}

--- a/src/app/features/operaciones/pages/menu/menu.ts
+++ b/src/app/features/operaciones/pages/menu/menu.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-operaciones-menu',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './menu.html',
+  styleUrl: './menu.scss'
+})
+export class OperacionesMenu {}

--- a/src/app/features/operaciones/pages/permisos/permisos.html
+++ b/src/app/features/operaciones/pages/permisos/permisos.html
@@ -1,0 +1,4 @@
+<section class="permisos">
+  <h1>Permisos por Usuario</h1>
+  <p>Gestión de permisos específicos para cada usuario.</p>
+</section>

--- a/src/app/features/operaciones/pages/permisos/permisos.scss
+++ b/src/app/features/operaciones/pages/permisos/permisos.scss
@@ -1,0 +1,3 @@
+.permisos {
+  padding: 2rem;
+}

--- a/src/app/features/operaciones/pages/permisos/permisos.ts
+++ b/src/app/features/operaciones/pages/permisos/permisos.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-permisos',
+  standalone: true,
+  templateUrl: './permisos.html',
+  styleUrl: './permisos.scss'
+})
+export class Permisos {}

--- a/src/app/features/operaciones/pages/planograma/planograma.html
+++ b/src/app/features/operaciones/pages/planograma/planograma.html
@@ -1,0 +1,4 @@
+<section class="planograma">
+  <h1>Planograma</h1>
+  <p>Administración de planogramas para cada vending.</p>
+</section>

--- a/src/app/features/operaciones/pages/planograma/planograma.scss
+++ b/src/app/features/operaciones/pages/planograma/planograma.scss
@@ -1,0 +1,3 @@
+.planograma {
+  padding: 2rem;
+}

--- a/src/app/features/operaciones/pages/planograma/planograma.ts
+++ b/src/app/features/operaciones/pages/planograma/planograma.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-planograma',
+  standalone: true,
+  templateUrl: './planograma.html',
+  styleUrl: './planograma.scss'
+})
+export class Planograma {}

--- a/src/app/features/operaciones/pages/resurtido/resurtido.html
+++ b/src/app/features/operaciones/pages/resurtido/resurtido.html
@@ -1,0 +1,4 @@
+<section class="resurtido">
+  <h1>Resurtido</h1>
+  <p>Registro y seguimiento de resurtido de productos.</p>
+</section>

--- a/src/app/features/operaciones/pages/resurtido/resurtido.scss
+++ b/src/app/features/operaciones/pages/resurtido/resurtido.scss
@@ -1,0 +1,3 @@
+.resurtido {
+  padding: 2rem;
+}

--- a/src/app/features/operaciones/pages/resurtido/resurtido.ts
+++ b/src/app/features/operaciones/pages/resurtido/resurtido.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-resurtido',
+  standalone: true,
+  templateUrl: './resurtido.html',
+  styleUrl: './resurtido.scss'
+})
+export class Resurtido {}

--- a/src/app/features/usuarios/pages/lista/lista.html
+++ b/src/app/features/usuarios/pages/lista/lista.html
@@ -1,0 +1,4 @@
+<section class="usuarios-lista">
+  <h1>Usuarios</h1>
+  <p>Administración de altas y bajas de usuarios.</p>
+</section>

--- a/src/app/features/usuarios/pages/lista/lista.scss
+++ b/src/app/features/usuarios/pages/lista/lista.scss
@@ -1,0 +1,3 @@
+.usuarios-lista {
+  padding: 2rem;
+}

--- a/src/app/features/usuarios/pages/lista/lista.ts
+++ b/src/app/features/usuarios/pages/lista/lista.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-usuarios-lista',
+  standalone: true,
+  templateUrl: './lista.html',
+  styleUrl: './lista.scss'
+})
+export class UsuariosLista {}

--- a/src/app/features/usuarios/pages/menu/menu.html
+++ b/src/app/features/usuarios/pages/menu/menu.html
@@ -1,0 +1,7 @@
+<section class="usuarios-menu">
+  <h1>Usuarios</h1>
+  <ul>
+    <li><a routerLink="lista">Listado</a></li>
+    <li><a routerLink="roles">Roles</a></li>
+  </ul>
+</section>

--- a/src/app/features/usuarios/pages/menu/menu.scss
+++ b/src/app/features/usuarios/pages/menu/menu.scss
@@ -1,0 +1,3 @@
+.usuarios-menu {
+  padding: 2rem;
+}

--- a/src/app/features/usuarios/pages/menu/menu.ts
+++ b/src/app/features/usuarios/pages/menu/menu.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-usuarios-menu',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './menu.html',
+  styleUrl: './menu.scss'
+})
+export class UsuariosMenu {}

--- a/src/app/features/usuarios/pages/roles/roles.html
+++ b/src/app/features/usuarios/pages/roles/roles.html
@@ -1,0 +1,4 @@
+<section class="roles">
+  <h1>Roles de Usuario</h1>
+  <p>Gestión de roles y permisos asignados.</p>
+</section>

--- a/src/app/features/usuarios/pages/roles/roles.scss
+++ b/src/app/features/usuarios/pages/roles/roles.scss
@@ -1,0 +1,3 @@
+.roles {
+  padding: 2rem;
+}

--- a/src/app/features/usuarios/pages/roles/roles.ts
+++ b/src/app/features/usuarios/pages/roles/roles.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-roles',
+  standalone: true,
+  templateUrl: './roles.html',
+  styleUrl: './roles.scss'
+})
+export class Roles {}

--- a/src/app/features/usuarios/usuarios-routing.module.ts
+++ b/src/app/features/usuarios/usuarios-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { UsuariosMenu } from './pages/menu/menu';
+import { UsuariosLista } from './pages/lista/lista';
+import { Roles } from './pages/roles/roles';
+
+const routes: Routes = [
+  { path: '', component: UsuariosMenu },
+  { path: 'lista', component: UsuariosLista },
+  { path: 'roles', component: Roles },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class UsuariosRoutingModule {}

--- a/src/app/features/usuarios/usuarios.module.ts
+++ b/src/app/features/usuarios/usuarios.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
+import { UsuariosRoutingModule } from './usuarios-routing.module';
+import { UsuariosMenu } from './pages/menu/menu';
+import { UsuariosLista } from './pages/lista/lista';
+import { Roles } from './pages/roles/roles';
+
+@NgModule({
+  declarations: [],
+  imports: [
+    CommonModule,
+    RouterModule,
+    UsuariosMenu,
+    UsuariosLista,
+    Roles,
+    UsuariosRoutingModule
+  ]
+})
+export class UsuariosModule {}


### PR DESCRIPTION
## Summary
- add modules for Operaciones with planograma, resurtido and permisos
- add Users, Employees and Almacenes management sections
- hook new modules into the main routes
- update sidebar and home page links

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b65dc01ec832ba997c4cc04a5169d