### PR TITLE
Restructure navigation for operations

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -3,13 +3,8 @@
   <aside class="sidebar" *ngIf="!isAuthRoute">
     <div class="brand">Vending Co.</div>
     <nav class="menu">
-      <a routerLink="/inicio" routerLinkActive="active">Inicio</a>
       <a routerLink="/reportes" routerLinkActive="active">Reportes</a>
       <a routerLink="/operaciones" routerLinkActive="active">Operaciones</a>
-      <a routerLink="/usuarios" routerLinkActive="active">Usuarios</a>
-      <a routerLink="/empleados" routerLinkActive="active">Empleados</a>
-      <a routerLink="/almacenes" routerLinkActive="active">Almacenes</a>
-      <a routerLink="/configuracion" routerLinkActive="active">Configuración</a>
     </nav>
   </aside>
 

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -7,11 +7,6 @@ export const routes: Routes = [
     pathMatch: 'full'
   },
   {
-    path: 'inicio',
-    loadChildren: () =>
-      import('./features/inicio/inicio.module').then(m => m.InicioModule)
-  },
-  {
     path: 'reportes',
     loadChildren: () =>
       import('./features/reportes/reportes.module').then(m => m.ReportesModule)
@@ -22,24 +17,8 @@ export const routes: Routes = [
       import('./features/operaciones/operaciones.module').then(m => m.OperacionesModule)
   },
   {
-    path: 'usuarios',
-    loadChildren: () =>
-      import('./features/usuarios/usuarios.module').then(m => m.UsuariosModule)
-  },
-  {
-    path: 'empleados',
-    loadChildren: () =>
-      import('./features/empleados/empleados.module').then(m => m.EmpleadosModule)
-  },
-  {
-    path: 'almacenes',
-    loadChildren: () =>
-      import('./features/almacenes/almacenes.module').then(m => m.AlmacenesModule)
-  },
-  {
     path: 'auth',
     loadChildren: () =>
       import('./features/auth/auth/auth.module').then(m => m.AuthModule)
   },
-  
 ];

--- a/src/app/features/inicio/pages/home/home.html
+++ b/src/app/features/inicio/pages/home/home.html
@@ -3,12 +3,7 @@
   <p>Selecciona una sección para comenzar:</p>
 
   <div class="menu">
-    <a routerLink="/reportes/usuarios/ventas" class="card">📊 Reportes</a>
-    <a routerLink="/reportes/vending/inventario" class="card">📦 Inventario</a>
+    <a routerLink="/reportes" class="card">📊 Reportes</a>
     <a routerLink="/operaciones" class="card">⚙️ Operaciones</a>
-    <a routerLink="/usuarios" class="card">👥 Usuarios</a>
-    <a routerLink="/empleados" class="card">🏢 Empleados</a>
-    <a routerLink="/almacenes" class="card">🏬 Almacenes</a>
-    <a routerLink="/configuracion" class="card">🔧 Configuración</a>
   </div>
 </section>

--- a/src/app/features/operaciones/operaciones-routing.module.ts
+++ b/src/app/features/operaciones/operaciones-routing.module.ts
@@ -1,19 +1,41 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { OperacionesMenu } from './pages/menu/menu';
+import { VendingMenu } from './pages/vending-menu/vending-menu';
 import { Planograma } from './pages/planograma/planograma';
 import { Resurtido } from './pages/resurtido/resurtido';
 import { Permisos } from './pages/permisos/permisos';
 
 const routes: Routes = [
   { path: '', component: OperacionesMenu },
-  { path: 'planograma', component: Planograma },
-  { path: 'resurtido', component: Resurtido },
-  { path: 'permisos', component: Permisos },
+  {
+    path: 'vending',
+    children: [
+      { path: '', component: VendingMenu },
+      { path: 'planograma', component: Planograma },
+      { path: 'resurtido', component: Resurtido },
+      { path: 'permisos', component: Permisos },
+    ],
+  },
+  {
+    path: 'usuarios',
+    loadChildren: () =>
+      import('../usuarios/usuarios.module').then(m => m.UsuariosModule),
+  },
+  {
+    path: 'empleados',
+    loadChildren: () =>
+      import('../empleados/empleados.module').then(m => m.EmpleadosModule),
+  },
+  {
+    path: 'almacenes',
+    loadChildren: () =>
+      import('../almacenes/almacenes.module').then(m => m.AlmacenesModule),
+  },
 ];
 
 @NgModule({
   imports: [RouterModule.forChild(routes)],
-  exports: [RouterModule]
+  exports: [RouterModule],
 })
 export class OperacionesRoutingModule {}

--- a/src/app/features/operaciones/operaciones.module.ts
+++ b/src/app/features/operaciones/operaciones.module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { OperacionesRoutingModule } from './operaciones-routing.module';
 import { OperacionesMenu } from './pages/menu/menu';
+import { VendingMenu } from './pages/vending-menu/vending-menu';
 import { Planograma } from './pages/planograma/planograma';
 import { Resurtido } from './pages/resurtido/resurtido';
 import { Permisos } from './pages/permisos/permisos';
@@ -13,6 +14,7 @@ import { Permisos } from './pages/permisos/permisos';
     CommonModule,
     RouterModule,
     OperacionesMenu,
+    VendingMenu,
     Planograma,
     Resurtido,
     Permisos,

--- a/src/app/features/operaciones/pages/menu/menu.html
+++ b/src/app/features/operaciones/pages/menu/menu.html
@@ -1,8 +1,9 @@
 <section class="operaciones-menu">
   <h1>Operaciones</h1>
   <ul>
-    <li><a routerLink="planograma">Planograma</a></li>
-    <li><a routerLink="resurtido">Resurtido</a></li>
-    <li><a routerLink="permisos">Permisos por usuario</a></li>
+    <li><a routerLink="vending">Vending</a></li>
+    <li><a routerLink="usuarios">Usuarios</a></li>
+    <li><a routerLink="empleados">Empleados</a></li>
+    <li><a routerLink="almacenes">Almacenes</a></li>
   </ul>
 </section>

--- a/src/app/features/operaciones/pages/vending-menu/vending-menu.html
+++ b/src/app/features/operaciones/pages/vending-menu/vending-menu.html
@@ -1,0 +1,8 @@
+<section class="vending-menu">
+  <h1>Vending</h1>
+  <ul>
+    <li><a routerLink="planograma">Planograma</a></li>
+    <li><a routerLink="resurtido">Resurtido</a></li>
+    <li><a routerLink="permisos">Permisos por usuario</a></li>
+  </ul>
+</section>

--- a/src/app/features/operaciones/pages/vending-menu/vending-menu.scss
+++ b/src/app/features/operaciones/pages/vending-menu/vending-menu.scss
@@ -1,0 +1,3 @@
+.vending-menu {
+  padding: 2rem;
+}

--- a/src/app/features/operaciones/pages/vending-menu/vending-menu.ts
+++ b/src/app/features/operaciones/pages/vending-menu/vending-menu.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+import { RouterLink } from '@angular/router';
+
+@Component({
+  selector: 'app-vending-menu',
+  standalone: true,
+  imports: [RouterLink],
+  templateUrl: './vending-menu.html',
+  styleUrl: './vending-menu.scss'
+})
+export class VendingMenu {}


### PR DESCRIPTION
## Summary
- simplify sidebar so only **Reportes** and **Operaciones** appear
- group user, employee and warehouse modules under **Operaciones**
- add new Vending menu component for planograma/resurtido/permisos
- update home page to match the new navigation

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b6878934c832bbeabbc2e497ea35d