### PR TITLE
Add nested operations routes and update login

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -4,11 +4,24 @@
     <div class="brand">Vending Co.</div>
     <nav class="menu">
       <a routerLink="/inicio" routerLinkActive="active">Inicio</a>
-      <a routerLink="/reportes" routerLinkActive="active">Reportes</a>
-      <a routerLink="/operaciones" routerLinkActive="active">Operaciones</a>
-      <a routerLink="/usuarios" routerLinkActive="active">Usuarios</a>
-      <a routerLink="/empleados" routerLinkActive="active">Empleados</a>
-      <a routerLink="/almacenes" routerLinkActive="active">Almacenes</a>
+
+      <div class="submenu">
+        <p class="section-title">Reportes</p>
+        <a routerLink="/reportes" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">Menú</a>
+        <a routerLink="/reportes/usuarios/ventas" routerLinkActive="active">Ventas</a>
+        <a routerLink="/reportes/usuarios/productos" routerLinkActive="active">Productos por usuario</a>
+        <a routerLink="/reportes/usuarios/usuarios" routerLinkActive="active">Usuarios</a>
+        <a routerLink="/reportes/vending/inventario" routerLinkActive="active">Inventario</a>
+      </div>
+
+      <div class="submenu">
+        <p class="section-title">Operaciones</p>
+        <a routerLink="/operaciones" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">Menú</a>
+        <a routerLink="/operaciones/usuarios" routerLinkActive="active">Usuarios</a>
+        <a routerLink="/operaciones/empleados" routerLinkActive="active">Empleados</a>
+        <a routerLink="/operaciones/almacenes" routerLinkActive="active">Almacenes</a>
+      </div>
+
       <a routerLink="/configuracion" routerLinkActive="active">Configuración</a>
     </nav>
   </aside>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -22,21 +22,6 @@ export const routes: Routes = [
       import('./features/operaciones/operaciones.module').then(m => m.OperacionesModule)
   },
   {
-    path: 'usuarios',
-    loadChildren: () =>
-      import('./features/usuarios/usuarios.module').then(m => m.UsuariosModule)
-  },
-  {
-    path: 'empleados',
-    loadChildren: () =>
-      import('./features/empleados/empleados.module').then(m => m.EmpleadosModule)
-  },
-  {
-    path: 'almacenes',
-    loadChildren: () =>
-      import('./features/almacenes/almacenes.module').then(m => m.AlmacenesModule)
-  },
-  {
     path: 'auth',
     loadChildren: () =>
       import('./features/auth/auth/auth.module').then(m => m.AuthModule)

--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -21,15 +21,28 @@
   color: #222;
 }
 
-.menu a {
-  display: block;
-  padding: 0.75rem 1rem;
-  margin-bottom: 0.5rem;
-  text-decoration: none;
-  color: #333;
-  border-radius: 5px;
-  transition: background-color 0.2s;
-}
+  .menu a {
+    display: block;
+    padding: 0.75rem 1rem;
+    margin-bottom: 0.5rem;
+    text-decoration: none;
+    color: #333;
+    border-radius: 5px;
+    transition: background-color 0.2s;
+  }
+
+  .submenu {
+    margin-bottom: 1rem;
+  }
+
+  .section-title {
+    margin: 0.5rem 1rem;
+    font-weight: bold;
+  }
+
+  .submenu a {
+    padding-left: 1.5rem;
+  }
 
 .menu a.active,
 .menu a:hover {

--- a/src/app/features/auth/pages/login/login.ts
+++ b/src/app/features/auth/pages/login/login.ts
@@ -16,7 +16,7 @@ export class LoginComponent {
   constructor(private router: Router) {}
 
   login() {
-    if (this.username && this.password) {
+    if (this.username === 'admin' && this.password === 'admin') {
       this.router.navigate(['/inicio']);
     } else {
       alert('Datos incorrectos');

--- a/src/app/features/inicio/pages/home/home.html
+++ b/src/app/features/inicio/pages/home/home.html
@@ -6,9 +6,9 @@
     <a routerLink="/reportes" class="card">📊 Reportes</a>
     <a routerLink="/reportes/vending/inventario" class="card">📦 Inventario</a>
     <a routerLink="/operaciones" class="card">⚙️ Operaciones</a>
-    <a routerLink="/usuarios" class="card">👥 Usuarios</a>
-    <a routerLink="/empleados" class="card">🏢 Empleados</a>
-    <a routerLink="/almacenes" class="card">🏬 Almacenes</a>
+    <a routerLink="/operaciones/usuarios" class="card">👥 Usuarios</a>
+    <a routerLink="/operaciones/empleados" class="card">🏢 Empleados</a>
+    <a routerLink="/operaciones/almacenes" class="card">🏬 Almacenes</a>
     <a routerLink="/configuracion" class="card">🔧 Configuración</a>
   </div>
 </section>

--- a/src/app/features/operaciones/operaciones-routing.module.ts
+++ b/src/app/features/operaciones/operaciones-routing.module.ts
@@ -10,6 +10,9 @@ const routes: Routes = [
   { path: 'planograma', component: Planograma },
   { path: 'resurtido', component: Resurtido },
   { path: 'permisos', component: Permisos },
+  { path: 'usuarios', loadChildren: () => import('../usuarios/usuarios.module').then(m => m.UsuariosModule) },
+  { path: 'empleados', loadChildren: () => import('../empleados/empleados.module').then(m => m.EmpleadosModule) },
+  { path: 'almacenes', loadChildren: () => import('../almacenes/almacenes.module').then(m => m.AlmacenesModule) },
 ];
 
 @NgModule({

--- a/src/app/features/operaciones/pages/menu/menu.html
+++ b/src/app/features/operaciones/pages/menu/menu.html
@@ -4,5 +4,8 @@
     <li><a routerLink="planograma">Planograma</a></li>
     <li><a routerLink="resurtido">Resurtido</a></li>
     <li><a routerLink="permisos">Permisos por usuario</a></li>
+    <li><a routerLink="usuarios">Usuarios</a></li>
+    <li><a routerLink="empleados">Empleados</a></li>
+    <li><a routerLink="almacenes">Almacenes</a></li>
   </ul>
 </section>


### PR DESCRIPTION
## Summary
- route `usuarios`, `empleados` and `almacenes` under `operaciones`
- verify credentials on login page
- update sidebar layout with nested menus
- link new routes from the home page

## Testing
- `npm test` *(fails: ng not found)*
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686dd9ba59f0832b97c075befd8456cf