### PR TITLE
Add basic API service connections

### DIFF
--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -3,9 +3,10 @@ import { Component } from '@angular/core';
 import { Router, RouterOutlet } from '@angular/router';
 import { RouterLink } from '@angular/router';
 import { RouterModule } from '@angular/router';
+import { HttpClientModule } from '@angular/common/http';
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, CommonModule, RouterLink,RouterModule],
+  imports: [RouterOutlet, CommonModule, RouterLink, RouterModule, HttpClientModule],
   templateUrl: './app.html',
   styleUrl: './app.scss'
 })

--- a/src/app/features/almacenes/pages/almacenes/almacenes.ts
+++ b/src/app/features/almacenes/pages/almacenes/almacenes.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-almacenes',
@@ -6,4 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './almacenes.html',
   styleUrl: './almacenes.scss'
 })
-export class Almacenes {}
+export class Almacenes implements OnInit {
+  almacenes: any;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('/almacenes').subscribe(data => (this.almacenes = data));
+  }
+}

--- a/src/app/features/almacenes/pages/menu/menu.ts
+++ b/src/app/features/almacenes/pages/menu/menu.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-almacenes-menu',
@@ -8,4 +9,10 @@ import { RouterLink } from '@angular/router';
   templateUrl: './menu.html',
   styleUrl: './menu.scss'
 })
-export class AlmacenesMenu {}
+export class AlmacenesMenu implements OnInit {
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('/almacenes/menu').subscribe();
+  }
+}

--- a/src/app/features/auth/pages/login/login.ts
+++ b/src/app/features/auth/pages/login/login.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-login',
@@ -13,13 +14,15 @@ export class LoginComponent {
   username = '';
   password = '';
 
-  constructor(private router: Router) {}
+  constructor(private router: Router, private api: ApiService) {}
 
   login() {
-    if (this.username === 'admin' && this.password === 'admin') {
-      this.router.navigate(['/inicio']);
-    } else {
-      alert('Datos incorrectos');
-    }
+    this.api.get('/login').subscribe(() => {
+      if (this.username === 'admin' && this.password === 'admin') {
+        this.router.navigate(['/inicio']);
+      } else {
+        alert('Datos incorrectos');
+      }
+    });
   }
 }

--- a/src/app/features/dashboard/pages/main/main.ts
+++ b/src/app/features/dashboard/pages/main/main.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-main',
@@ -6,6 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './main.html',
   styleUrl: './main.scss'
 })
-export class Main {
+export class Main implements OnInit {
+  data: any;
 
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('/dashboard').subscribe(d => (this.data = d));
+  }
 }

--- a/src/app/features/empleados/pages/areas/areas.ts
+++ b/src/app/features/empleados/pages/areas/areas.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-areas',
@@ -6,4 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './areas.html',
   styleUrl: './areas.scss'
 })
-export class Areas {}
+export class Areas implements OnInit {
+  areas: any;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('/areas').subscribe(data => (this.areas = data));
+  }
+}

--- a/src/app/features/empleados/pages/departamentos/departamentos.ts
+++ b/src/app/features/empleados/pages/departamentos/departamentos.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-departamentos',
@@ -6,4 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './departamentos.html',
   styleUrl: './departamentos.scss'
 })
-export class Departamentos {}
+export class Departamentos implements OnInit {
+  departamentos: any;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('/departamentos').subscribe(data => (this.departamentos = data));
+  }
+}

--- a/src/app/features/empleados/pages/empleados/empleados.ts
+++ b/src/app/features/empleados/pages/empleados/empleados.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-empleados',
@@ -6,4 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './empleados.html',
   styleUrl: './empleados.scss'
 })
-export class Empleados {}
+export class Empleados implements OnInit {
+  empleados: any;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('/empleados').subscribe(data => (this.empleados = data));
+  }
+}

--- a/src/app/features/empleados/pages/menu/menu.ts
+++ b/src/app/features/empleados/pages/menu/menu.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-empleados-menu',
@@ -8,4 +9,10 @@ import { RouterLink } from '@angular/router';
   templateUrl: './menu.html',
   styleUrl: './menu.scss'
 })
-export class EmpleadosMenu {}
+export class EmpleadosMenu implements OnInit {
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('/empleados/menu').subscribe();
+  }
+}

--- a/src/app/features/inicio/pages/home/home.ts
+++ b/src/app/features/inicio/pages/home/home.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-home',
@@ -8,6 +9,12 @@ import { RouterLink } from '@angular/router';
   templateUrl: './home.html',
   styleUrl: './home.scss'
 })
-export class Home {
+export class Home implements OnInit {
+  data: any;
 
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('/home').subscribe(d => (this.data = d));
+  }
 }

--- a/src/app/features/inventario/pages/inventario/inventario.ts
+++ b/src/app/features/inventario/pages/inventario/inventario.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-inventario',
@@ -6,4 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './inventario.html',
   styleUrl: './inventario.scss'
 })
-export class Inventario {}
+export class Inventario implements OnInit {
+  inventario: any;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('/inventario').subscribe(data => (this.inventario = data));
+  }
+}

--- a/src/app/features/operaciones/pages/menu/menu.ts
+++ b/src/app/features/operaciones/pages/menu/menu.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-operaciones-menu',
@@ -8,4 +9,10 @@ import { RouterLink } from '@angular/router';
   templateUrl: './menu.html',
   styleUrl: './menu.scss'
 })
-export class OperacionesMenu {}
+export class OperacionesMenu implements OnInit {
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('/operaciones/menu').subscribe();
+  }
+}

--- a/src/app/features/operaciones/pages/permisos/permisos.ts
+++ b/src/app/features/operaciones/pages/permisos/permisos.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-permisos',
@@ -6,4 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './permisos.html',
   styleUrl: './permisos.scss'
 })
-export class Permisos {}
+export class Permisos implements OnInit {
+  permisos: any;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('/permisos').subscribe(data => (this.permisos = data));
+  }
+}

--- a/src/app/features/operaciones/pages/planograma/planograma.ts
+++ b/src/app/features/operaciones/pages/planograma/planograma.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-planograma',
@@ -6,4 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './planograma.html',
   styleUrl: './planograma.scss'
 })
-export class Planograma {}
+export class Planograma implements OnInit {
+  planograma: any;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('/planograma').subscribe(data => (this.planograma = data));
+  }
+}

--- a/src/app/features/operaciones/pages/resurtido/resurtido.ts
+++ b/src/app/features/operaciones/pages/resurtido/resurtido.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-resurtido',
@@ -6,4 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './resurtido.html',
   styleUrl: './resurtido.scss'
 })
-export class Resurtido {}
+export class Resurtido implements OnInit {
+  resurtido: any;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('/resurtido').subscribe(data => (this.resurtido = data));
+  }
+}

--- a/src/app/features/reportes/pages/menu/menu.ts
+++ b/src/app/features/reportes/pages/menu/menu.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-reportes-menu',
@@ -8,4 +9,10 @@ import { RouterLink } from '@angular/router';
   templateUrl: './menu.html',
   styleUrl: './menu.scss'
 })
-export class ReportesMenu {}
+export class ReportesMenu implements OnInit {
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('/reportes/menu').subscribe();
+  }
+}

--- a/src/app/features/reportes/usuarios/pages/productos-x-empleado/productos-x-empleado.ts
+++ b/src/app/features/reportes/usuarios/pages/productos-x-empleado/productos-x-empleado.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../../services/api.service';
 
 @Component({
   selector: 'app-productos-x-empleado',
@@ -6,6 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './productos-x-empleado.html',
   styleUrl: './productos-x-empleado.scss'
 })
-export class ProductosXEmpleado {
+export class ProductosXEmpleado implements OnInit {
+  productos: any;
 
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('/reportes/usuarios/productos').subscribe(data => (this.productos = data));
+  }
 }

--- a/src/app/features/reportes/usuarios/pages/usuarios/usuarios.ts
+++ b/src/app/features/reportes/usuarios/pages/usuarios/usuarios.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../../services/api.service';
 
 @Component({
   selector: 'app-usuarios',
@@ -6,6 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './usuarios.html',
   styleUrl: './usuarios.scss'
 })
-export class Usuarios {
+export class Usuarios implements OnInit {
+  usuarios: any;
 
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('/reportes/usuarios/usuarios').subscribe(data => (this.usuarios = data));
+  }
 }

--- a/src/app/features/reportes/usuarios/pages/ventas/ventas.ts
+++ b/src/app/features/reportes/usuarios/pages/ventas/ventas.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../../services/api.service';
 
 @Component({
   selector: 'app-ventas',
@@ -6,7 +7,13 @@ import { Component } from '@angular/core';
   templateUrl: './ventas.html',
   styleUrl: './ventas.scss'
 })
-export class Ventas {
+export class Ventas implements OnInit {
+  ventas: any;
 
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('/reportes/usuarios/ventas').subscribe(data => (this.ventas = data));
+  }
 }
 

--- a/src/app/features/usuarios/pages/lista/lista.ts
+++ b/src/app/features/usuarios/pages/lista/lista.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-usuarios-lista',
@@ -6,4 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './lista.html',
   styleUrl: './lista.scss'
 })
-export class UsuariosLista {}
+export class UsuariosLista implements OnInit {
+  usuarios: any;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('/usuarios').subscribe(data => (this.usuarios = data));
+  }
+}

--- a/src/app/features/usuarios/pages/menu/menu.ts
+++ b/src/app/features/usuarios/pages/menu/menu.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-usuarios-menu',
@@ -8,4 +9,10 @@ import { RouterLink } from '@angular/router';
   templateUrl: './menu.html',
   styleUrl: './menu.scss'
 })
-export class UsuariosMenu {}
+export class UsuariosMenu implements OnInit {
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('/usuarios/menu').subscribe();
+  }
+}

--- a/src/app/features/usuarios/pages/roles/roles.ts
+++ b/src/app/features/usuarios/pages/roles/roles.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-roles',
@@ -6,4 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './roles.html',
   styleUrl: './roles.scss'
 })
-export class Roles {}
+export class Roles implements OnInit {
+  roles: any;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('/usuarios/roles').subscribe(data => (this.roles = data));
+  }
+}

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+
+const API_BASE_URL = 'http://localhost:3000/api';
+
+@Injectable({ providedIn: 'root' })
+export class ApiService {
+  constructor(private http: HttpClient) {}
+
+  get<T>(endpoint: string): Observable<T> {
+    return this.http.get<T>(API_BASE_URL + endpoint);
+  }
+}


### PR DESCRIPTION
## Summary
- add an ApiService to centralize backend calls
- inject HttpClientModule in the root App component
- call the API service from all feature pages

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f482b3ab4832bba3a73ec17f45f52