### PR TITLE
Fix router base path

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -17,7 +17,7 @@
         "build": {
           "builder": "@angular/build:application",
           "options": {
-            "baseHref": "/vending-manager/",
+            "baseHref": "/",
             "browser": "src/main.ts",
             "polyfills": [
               "zone.js"


### PR DESCRIPTION
## Summary
- fix `angular.json` so the dev server works at `/` instead of `/vending-manager/`

## Testing
- `npm run build` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_686f6a1e10d8832ba23185c904d2759c