### PR TITLE
Add API integration across pages

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,5 +1,6 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZoneChangeDetection } from '@angular/core';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
 
 import { routes } from './app.routes';
 
@@ -7,6 +8,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZoneChangeDetection({ eventCoalescing: true }),
-    provideRouter(routes)
+    provideRouter(routes),
+    provideHttpClient()
   ]
 };

--- a/src/app/features/almacenes/pages/almacenes/almacenes.ts
+++ b/src/app/features/almacenes/pages/almacenes/almacenes.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-almacenes',
@@ -6,4 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './almacenes.html',
   styleUrl: './almacenes.scss'
 })
-export class Almacenes {}
+export class Almacenes implements OnInit {
+  data: unknown;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('almacenes').subscribe(d => (this.data = d));
+  }
+}

--- a/src/app/features/almacenes/pages/menu/menu.ts
+++ b/src/app/features/almacenes/pages/menu/menu.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-almacenes-menu',
@@ -8,4 +9,12 @@ import { RouterLink } from '@angular/router';
   templateUrl: './menu.html',
   styleUrl: './menu.scss'
 })
-export class AlmacenesMenu {}
+export class AlmacenesMenu implements OnInit {
+  data: unknown;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('almacenes-menu').subscribe(d => (this.data = d));
+  }
+}

--- a/src/app/features/auth/pages/login/login.spec.ts
+++ b/src/app/features/auth/pages/login/login.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { Login } from './login';
 
@@ -8,7 +9,7 @@ describe('Login', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Login]
+      imports: [Login, HttpClientTestingModule]
     })
     .compileComponents();
 

--- a/src/app/features/auth/pages/login/login.ts
+++ b/src/app/features/auth/pages/login/login.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-login',
@@ -13,13 +14,20 @@ export class LoginComponent {
   username = '';
   password = '';
 
-  constructor(private router: Router) {}
+  constructor(private router: Router, private api: ApiService) {}
 
   login() {
-    if (this.username && this.password) {
-      this.router.navigate(['/inicio']);
-    } else {
+    if (!this.username || !this.password) {
       alert('Datos incorrectos');
+      return;
     }
+
+    this.api.post('login', {
+      username: this.username,
+      password: this.password
+    }).subscribe({
+      next: () => this.router.navigate(['/inicio']),
+      error: () => alert('Datos incorrectos')
+    });
   }
 }

--- a/src/app/features/dashboard/pages/main/main.spec.ts
+++ b/src/app/features/dashboard/pages/main/main.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { Main } from './main';
 
@@ -8,7 +9,7 @@ describe('Main', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Main]
+      imports: [Main, HttpClientTestingModule]
     })
     .compileComponents();
 

--- a/src/app/features/dashboard/pages/main/main.ts
+++ b/src/app/features/dashboard/pages/main/main.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-main',
@@ -6,6 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './main.html',
   styleUrl: './main.scss'
 })
-export class Main {
+export class Main implements OnInit {
+  data: unknown;
 
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('dashboard').subscribe(d => (this.data = d));
+  }
 }

--- a/src/app/features/empleados/pages/areas/areas.ts
+++ b/src/app/features/empleados/pages/areas/areas.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-areas',
@@ -6,4 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './areas.html',
   styleUrl: './areas.scss'
 })
-export class Areas {}
+export class Areas implements OnInit {
+  data: unknown;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('areas').subscribe(d => (this.data = d));
+  }
+}

--- a/src/app/features/empleados/pages/departamentos/departamentos.ts
+++ b/src/app/features/empleados/pages/departamentos/departamentos.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-departamentos',
@@ -6,4 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './departamentos.html',
   styleUrl: './departamentos.scss'
 })
-export class Departamentos {}
+export class Departamentos implements OnInit {
+  data: unknown;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('departamentos').subscribe(d => (this.data = d));
+  }
+}

--- a/src/app/features/empleados/pages/empleados/empleados.ts
+++ b/src/app/features/empleados/pages/empleados/empleados.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-empleados',
@@ -6,4 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './empleados.html',
   styleUrl: './empleados.scss'
 })
-export class Empleados {}
+export class Empleados implements OnInit {
+  data: unknown;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('empleados').subscribe(d => (this.data = d));
+  }
+}

--- a/src/app/features/empleados/pages/menu/menu.ts
+++ b/src/app/features/empleados/pages/menu/menu.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-empleados-menu',
@@ -8,4 +9,12 @@ import { RouterLink } from '@angular/router';
   templateUrl: './menu.html',
   styleUrl: './menu.scss'
 })
-export class EmpleadosMenu {}
+export class EmpleadosMenu implements OnInit {
+  data: unknown;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('empleados-menu').subscribe(d => (this.data = d));
+  }
+}

--- a/src/app/features/inicio/pages/home/home.spec.ts
+++ b/src/app/features/inicio/pages/home/home.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { Home } from './home';
 
@@ -8,7 +9,7 @@ describe('Home', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Home]
+      imports: [Home, HttpClientTestingModule]
     })
     .compileComponents();
 

--- a/src/app/features/inicio/pages/home/home.ts
+++ b/src/app/features/inicio/pages/home/home.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-home',
@@ -8,6 +9,12 @@ import { RouterLink } from '@angular/router';
   templateUrl: './home.html',
   styleUrl: './home.scss'
 })
-export class Home {
+export class Home implements OnInit {
+  data: unknown;
 
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('home').subscribe(d => (this.data = d));
+  }
 }

--- a/src/app/features/inventario/pages/inventario/inventario.ts
+++ b/src/app/features/inventario/pages/inventario/inventario.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-inventario',
@@ -6,4 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './inventario.html',
   styleUrl: './inventario.scss'
 })
-export class Inventario {}
+export class Inventario implements OnInit {
+  data: unknown;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('inventario').subscribe(d => (this.data = d));
+  }
+}

--- a/src/app/features/operaciones/pages/menu/menu.ts
+++ b/src/app/features/operaciones/pages/menu/menu.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-operaciones-menu',
@@ -8,4 +9,12 @@ import { RouterLink } from '@angular/router';
   templateUrl: './menu.html',
   styleUrl: './menu.scss'
 })
-export class OperacionesMenu {}
+export class OperacionesMenu implements OnInit {
+  data: unknown;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('operaciones-menu').subscribe(d => (this.data = d));
+  }
+}

--- a/src/app/features/operaciones/pages/permisos/permisos.ts
+++ b/src/app/features/operaciones/pages/permisos/permisos.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-permisos',
@@ -6,4 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './permisos.html',
   styleUrl: './permisos.scss'
 })
-export class Permisos {}
+export class Permisos implements OnInit {
+  data: unknown;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('permisos').subscribe(d => (this.data = d));
+  }
+}

--- a/src/app/features/operaciones/pages/planograma/planograma.ts
+++ b/src/app/features/operaciones/pages/planograma/planograma.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-planograma',
@@ -6,4 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './planograma.html',
   styleUrl: './planograma.scss'
 })
-export class Planograma {}
+export class Planograma implements OnInit {
+  data: unknown;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('planograma').subscribe(d => (this.data = d));
+  }
+}

--- a/src/app/features/operaciones/pages/resurtido/resurtido.ts
+++ b/src/app/features/operaciones/pages/resurtido/resurtido.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-resurtido',
@@ -6,4 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './resurtido.html',
   styleUrl: './resurtido.scss'
 })
-export class Resurtido {}
+export class Resurtido implements OnInit {
+  data: unknown;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('resurtido').subscribe(d => (this.data = d));
+  }
+}

--- a/src/app/features/reportes/pages/menu/menu.spec.ts
+++ b/src/app/features/reportes/pages/menu/menu.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ReportesMenu } from './menu';
 
 describe('ReportesMenu', () => {
@@ -7,7 +8,7 @@ describe('ReportesMenu', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ReportesMenu]
+      imports: [ReportesMenu, HttpClientTestingModule]
     }).compileComponents();
 
     fixture = TestBed.createComponent(ReportesMenu);

--- a/src/app/features/reportes/pages/menu/menu.ts
+++ b/src/app/features/reportes/pages/menu/menu.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-reportes-menu',
@@ -8,4 +9,12 @@ import { RouterLink } from '@angular/router';
   templateUrl: './menu.html',
   styleUrl: './menu.scss'
 })
-export class ReportesMenu {}
+export class ReportesMenu implements OnInit {
+  data: unknown;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('reportes-menu').subscribe(d => (this.data = d));
+  }
+}

--- a/src/app/features/reportes/usuarios/pages/productos-x-empleado/productos-x-empleado.spec.ts
+++ b/src/app/features/reportes/usuarios/pages/productos-x-empleado/productos-x-empleado.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { ProductosXEmpleado } from './productos-x-empleado';
 
@@ -8,7 +9,7 @@ describe('ProductosXEmpleado', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [ProductosXEmpleado]
+      imports: [ProductosXEmpleado, HttpClientTestingModule]
     })
     .compileComponents();
 

--- a/src/app/features/reportes/usuarios/pages/productos-x-empleado/productos-x-empleado.ts
+++ b/src/app/features/reportes/usuarios/pages/productos-x-empleado/productos-x-empleado.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../../../services/api.service';
 
 @Component({
   selector: 'app-productos-x-empleado',
@@ -6,6 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './productos-x-empleado.html',
   styleUrl: './productos-x-empleado.scss'
 })
-export class ProductosXEmpleado {
+export class ProductosXEmpleado implements OnInit {
+  data: unknown;
 
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('reportes/productos-x-empleado').subscribe(d => (this.data = d));
+  }
 }

--- a/src/app/features/reportes/usuarios/pages/usuarios/usuarios.spec.ts
+++ b/src/app/features/reportes/usuarios/pages/usuarios/usuarios.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { Usuarios } from './usuarios';
 
@@ -8,7 +9,7 @@ describe('Usuarios', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Usuarios]
+      imports: [Usuarios, HttpClientTestingModule]
     })
     .compileComponents();
 

--- a/src/app/features/reportes/usuarios/pages/usuarios/usuarios.ts
+++ b/src/app/features/reportes/usuarios/pages/usuarios/usuarios.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../../../services/api.service';
 
 @Component({
   selector: 'app-usuarios',
@@ -6,6 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './usuarios.html',
   styleUrl: './usuarios.scss'
 })
-export class Usuarios {
+export class Usuarios implements OnInit {
+  data: unknown;
 
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('reportes/usuarios').subscribe(d => (this.data = d));
+  }
 }

--- a/src/app/features/reportes/usuarios/pages/ventas/ventas.spec.ts
+++ b/src/app/features/reportes/usuarios/pages/ventas/ventas.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 import { Ventas } from './ventas';
 
@@ -8,7 +9,7 @@ describe('Ventas', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [Ventas]
+      imports: [Ventas, HttpClientTestingModule]
     })
     .compileComponents();
 

--- a/src/app/features/reportes/usuarios/pages/ventas/ventas.ts
+++ b/src/app/features/reportes/usuarios/pages/ventas/ventas.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../../../services/api.service';
 
 @Component({
   selector: 'app-ventas',
@@ -6,7 +7,13 @@ import { Component } from '@angular/core';
   templateUrl: './ventas.html',
   styleUrl: './ventas.scss'
 })
-export class Ventas {
+export class Ventas implements OnInit {
+  data: unknown;
 
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('reportes/ventas').subscribe(d => (this.data = d));
+  }
 }
 

--- a/src/app/features/usuarios/pages/lista/lista.ts
+++ b/src/app/features/usuarios/pages/lista/lista.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-usuarios-lista',
@@ -6,4 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './lista.html',
   styleUrl: './lista.scss'
 })
-export class UsuariosLista {}
+export class UsuariosLista implements OnInit {
+  data: unknown;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('usuarios-lista').subscribe(d => (this.data = d));
+  }
+}

--- a/src/app/features/usuarios/pages/menu/menu.ts
+++ b/src/app/features/usuarios/pages/menu/menu.ts
@@ -1,5 +1,6 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-usuarios-menu',
@@ -8,4 +9,12 @@ import { RouterLink } from '@angular/router';
   templateUrl: './menu.html',
   styleUrl: './menu.scss'
 })
-export class UsuariosMenu {}
+export class UsuariosMenu implements OnInit {
+  data: unknown;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('usuarios-menu').subscribe(d => (this.data = d));
+  }
+}

--- a/src/app/features/usuarios/pages/roles/roles.ts
+++ b/src/app/features/usuarios/pages/roles/roles.ts
@@ -1,4 +1,5 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
   selector: 'app-roles',
@@ -6,4 +7,12 @@ import { Component } from '@angular/core';
   templateUrl: './roles.html',
   styleUrl: './roles.scss'
 })
-export class Roles {}
+export class Roles implements OnInit {
+  data: unknown;
+
+  constructor(private api: ApiService) {}
+
+  ngOnInit(): void {
+    this.api.get('roles').subscribe(d => (this.data = d));
+  }
+}

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class ApiService {
+  constructor(private http: HttpClient) {}
+
+  get<T>(path: string): Observable<T> {
+    return this.http.get<T>(`${environment.apiUrl}/${path}`);
+  }
+
+  post<T>(path: string, body: unknown): Observable<T> {
+    return this.http.post<T>(`${environment.apiUrl}/${path}`, body);
+  }
+}

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,0 +1,3 @@
+export const environment = {
+  apiUrl: 'http://localhost:3000/api'
+};


### PR DESCRIPTION
## Summary
- provide HttpClient in `app.config`
- add environment file for API base URL
- implement an `ApiService` for HTTP requests
- inject `ApiService` into every page component
- update specs to use `HttpClientTestingModule`

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870700afd68832bac0917d236256fa2