### PR TITLE
Add administracion menu routes

### DIFF
--- a/src/app/features/administracion/administracion-routing.module.ts
+++ b/src/app/features/administracion/administracion-routing.module.ts
@@ -1,16 +1,25 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
-import { UsuariosModule } from './usuarios/usuarios.module';
-
+import { AdministracionMenu } from './pages/menu/menu';
 
 const routes: Routes = [
-  {path: 'usuario_admin', loadChildren: () => import('./usuarios/usuarios.module').then(m => m.UsuariosModule)},
-  {path: 'empleado_admin', loadChildren: () => import('./empleados/empleados.module').then(m => m.EmpleadosModule)},
-  {path: 'almacenes_admin', loadChildren: () => import('./almacenes/almacenes.module').then(m => m.AlmacenesModule)},
+  { path: '', component: AdministracionMenu },
+  {
+    path: 'usuarios',
+    loadChildren: () => import('./usuarios/usuarios.module').then(m => m.UsuariosModule)
+  },
+  {
+    path: 'empleados',
+    loadChildren: () => import('./empleados/empleados.module').then(m => m.EmpleadosModule)
+  },
+  {
+    path: 'almacenes',
+    loadChildren: () => import('./almacenes/almacenes.module').then(m => m.AlmacenesModule)
+  },
 ];
 
 @NgModule({
   imports: [RouterModule.forChild(routes)],
   exports: [RouterModule]
 })
-export class ReportesRoutingModule { }
+export class AdministracionRoutingModule { }

--- a/src/app/features/administracion/administracion.module.ts
+++ b/src/app/features/administracion/administracion.module.ts
@@ -1,9 +1,9 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
-import { AdministracionRoutingModule } from 'administracion.module';
-import { AdministracionMenu } from './pages/menu/menu';
+import { AdministracionRoutingModule } from './administracion-routing.module';
 import { FormsModule } from '@angular/forms';
+import { AdministracionMenu } from './pages/menu/menu';
 
 @NgModule({
   declarations: [],
@@ -16,4 +16,3 @@ import { FormsModule } from '@angular/forms';
   ]
 })
 export class AdministracionModule { }
-src\app\features\administracion\administracion-routing.module.ts

--- a/src/app/features/administracion/almacenes/pages/menu/menu.html
+++ b/src/app/features/administracion/almacenes/pages/menu/menu.html
@@ -1,1 +1,6 @@
-// ...existing code...
+<section class="almacenes-menu">
+  <h1>Almacenes</h1>
+  <ul>
+    <li><a routerLink="almacenes">Lista</a></li>
+  </ul>
+</section>

--- a/src/app/features/administracion/almacenes/pages/menu/menu.scss
+++ b/src/app/features/administracion/almacenes/pages/menu/menu.scss
@@ -1,1 +1,3 @@
-// ...existing code...
+.almacenes-menu {
+  padding: 2rem;
+}

--- a/src/app/features/administracion/almacenes/pages/menu/menu.ts
+++ b/src/app/features/administracion/almacenes/pages/menu/menu.ts
@@ -4,9 +4,9 @@ import { ApiService } from '../../../../../services/api.service';
 
 
 @Component({
-  selector: 'app-operaciones-menu',
+  selector: 'app-almacenes-menu',
   standalone: true,
-  imports: [],
+  imports: [RouterLink],
   templateUrl: './menu.html',
   styleUrl: './menu.scss'
 })
@@ -16,6 +16,6 @@ export class Menu implements OnInit {
   constructor(private api: ApiService) {}
 
   ngOnInit(): void {
-    this.api.get('operaciones-menu').subscribe(d => (this.data = d));
+    this.api.get('almacenes-menu').subscribe(d => (this.data = d));
   }
 }

--- a/src/app/features/administracion/empleados/pages/menu/menu.html
+++ b/src/app/features/administracion/empleados/pages/menu/menu.html
@@ -1,1 +1,8 @@
-// ...existing code...
+<section class="empleados-menu">
+  <h1>Empleados</h1>
+  <ul>
+    <li><a routerLink="empleados">Lista</a></li>
+    <li><a routerLink="areas">Áreas</a></li>
+    <li><a routerLink="departamentos">Departamentos</a></li>
+  </ul>
+</section>

--- a/src/app/features/administracion/empleados/pages/menu/menu.scss
+++ b/src/app/features/administracion/empleados/pages/menu/menu.scss
@@ -1,1 +1,3 @@
-// ...existing code...
+.empleados-menu {
+  padding: 2rem;
+}

--- a/src/app/features/administracion/empleados/pages/menu/menu.ts
+++ b/src/app/features/administracion/empleados/pages/menu/menu.ts
@@ -4,9 +4,9 @@ import { ApiService } from '../../../../../services/api.service';
 
 
 @Component({
-  selector: 'app-operaciones-menu',
+  selector: 'app-empleados-menu',
   standalone: true,
-  imports: [],
+  imports: [RouterLink],
   templateUrl: './menu.html',
   styleUrl: './menu.scss'
 })
@@ -16,6 +16,6 @@ export class Menu implements OnInit {
   constructor(private api: ApiService) {}
 
   ngOnInit(): void {
-    this.api.get('operaciones-menu').subscribe(d => (this.data = d));
+    this.api.get('empleados-menu').subscribe(d => (this.data = d));
   }
 }

--- a/src/app/features/administracion/pages/menu/menu.html
+++ b/src/app/features/administracion/pages/menu/menu.html
@@ -1,0 +1,8 @@
+<section class="administracion-menu">
+  <h1>Administración</h1>
+  <ul>
+    <li><a routerLink="usuarios">Usuarios</a></li>
+    <li><a routerLink="empleados">Empleados</a></li>
+    <li><a routerLink="almacenes">Almacenes</a></li>
+  </ul>
+</section>

--- a/src/app/features/administracion/pages/menu/menu.scss
+++ b/src/app/features/administracion/pages/menu/menu.scss
@@ -1,0 +1,3 @@
+.administracion-menu {
+  padding: 2rem;
+}

--- a/src/app/features/administracion/pages/menu/menu.ts
+++ b/src/app/features/administracion/pages/menu/menu.ts
@@ -1,21 +1,20 @@
 import { Component, OnInit } from '@angular/core';
 import { RouterLink } from '@angular/router';
-import { ApiService } from '../../../../../services/api.service';
-
+import { ApiService } from '../../../../services/api.service';
 
 @Component({
-  selector: 'app-usuarios-menu',
+  selector: 'app-administracion-menu',
   standalone: true,
   imports: [RouterLink],
   templateUrl: './menu.html',
   styleUrl: './menu.scss'
 })
-export class Menu implements OnInit {
+export class AdministracionMenu implements OnInit {
   data: unknown;
 
   constructor(private api: ApiService) {}
 
   ngOnInit(): void {
-    this.api.get('usuarios-menu').subscribe(d => (this.data = d));
+    this.api.get('administracion-menu').subscribe(d => (this.data = d));
   }
 }

--- a/src/app/features/administracion/usuarios/pages/menu/menu.html
+++ b/src/app/features/administracion/usuarios/pages/menu/menu.html
@@ -1,1 +1,7 @@
-// ...existing code...
+<section class="usuarios-menu">
+  <h1>Usuarios</h1>
+  <ul>
+    <li><a routerLink="lista">Lista</a></li>
+    <li><a routerLink="roles">Roles</a></li>
+  </ul>
+</section>

--- a/src/app/features/administracion/usuarios/pages/menu/menu.scss
+++ b/src/app/features/administracion/usuarios/pages/menu/menu.scss
@@ -1,1 +1,3 @@
-// ...existing code...
+.usuarios-menu {
+  padding: 2rem;
+}


### PR DESCRIPTION
## Summary
- add AdministracionMenu component with template and style
- hook AdministracionMenu into routing
- create simple menus for Usuarios, Empleados and Almacenes
- update AdministracionModule imports

## Testing
- `npm test` *(fails: ng not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68744dc4265c832b9289f3615bd66b02